### PR TITLE
make Serializer's validator_instance non-shared among requests 

### DIFF
--- a/django_alt/__legacy__/django_alt/abstract/serializers.py
+++ b/django_alt/__legacy__/django_alt/abstract/serializers.py
@@ -30,7 +30,7 @@ class BaseValidatedSerializer(serializers.Serializer):
         self.permission_test = permission_test
         self.did_check_permission = False
 
-        self.Meta.validator_instance = self._instantiate_validator(request=request, **kwargs)
+        self.validator_instance = self._instantiate_validator(request=request, **kwargs)
         super().__init__(instance, data, **kwargs)
 
     @staticmethod
@@ -50,7 +50,7 @@ class BaseValidatedSerializer(serializers.Serializer):
         serializer subclasses.
         :return: validator instance
         """
-        return self.Meta.validator_instance
+        return self.validator_instance
 
     @property
     def is_update(self) -> bool:

--- a/django_alt/__legacy__/django_alt_tests/tests/test_serializers.py
+++ b/django_alt/__legacy__/django_alt_tests/tests/test_serializers.py
@@ -20,7 +20,7 @@ def generate_serializer(validator_class):
             validator_class = cls
 
         def create(self, validated_data):
-            self.Meta.validator_instance.did_create(validated_data, validated_data)
+            self.validator_instance.did_create(validated_data, validated_data)
             return validated_data
 
     return ConcreteSerializer


### PR DESCRIPTION
Storing `validator_instance` in (static) Meta caused bugs, if several requests overlapped (using same Serializer).
So, when `validator_instance` was re-created it "lost" context. Ex.  `RoomBookingValidator`.`did_create` was randomly failing because of this.