### PR TITLE
in `create many` apply `will_create` and `base_db`

### DIFF
--- a/django_alt/__legacy__/django_alt/managers.py
+++ b/django_alt/__legacy__/django_alt/managers.py
@@ -75,6 +75,8 @@ class ValidatedManager:
         list_of_attrs = list(list_of_attrs)
         for attrs in list_of_attrs:
             self.validation_sequence(attrs)
+            attrs = coal(self.validator.will_create(attrs), attrs)
+            attrs = coal(self.validator.base_db(attrs), attrs)
             instances.append(self.model(**attrs))
 
         self.model.objects.bulk_create(instances)


### PR DESCRIPTION
these two hooks were missing. Don't know if it was on purpose?
ps.: same in `master` branch: https://github.com/poskadesign/django-alt/blob/master/django_alt/managers.py